### PR TITLE
Trigger functional testing from edgex-taf repo

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,177 @@
+#!/usr/bin/env groovy
+def LOGFILES
+
+call([
+    project: 'funcational-test',
+    mavenSettings: ['functional-testing-settings:SETTINGS_FILE']
+])
+
+def call(config) {
+    edgex.bannerMessage "[functional-testing] RAW Config: ${config}"
+
+    edgeXGeneric.validate(config)
+    edgex.setupNodes(config)
+
+    def _envVarMap = edgeXGeneric.toEnvironment(config)
+
+    pipeline {
+        agent { label edgex.mainNode(config) }
+        options { 
+            timeout(time: 2, unit: 'HOURS')
+            timestamps() 
+        }
+
+        environment {
+            // Define test branches and device services
+            BRANCHLIST = 'master'
+            PROFILELIST = 'device-virtual,device-modbus'
+            TAF_COMMOM_IMAGE_AMD64 = 'nexus3.edgexfoundry.org:10003/docker-edgex-taf-common:latest'
+            TAF_COMMOM_IMAGE_ARM64 = 'nexus3.edgexfoundry.org:10003/docker-edgex-taf-common-arm64:latest'
+            COMPOSE_IMAGE_AMD64 = 'nexus3.edgexfoundry.org:10003/edgex-devops/edgex-compose:latest'
+            COMPOSE_IMAGE_ARM64 = 'nexus3.edgexfoundry.org:10003/edgex-devops/edgex-compose-arm64:latest'
+        }
+
+        stages {
+            stage ('Run Test') {
+                parallel {
+                    stage ('Run Test on amd64') {
+                        environment {
+                            ARCH = 'x86_64'
+                            SLAVE = edgex.getNode(config, 'amd64')
+                            TAF_COMMOM_IMAGE = "${TAF_COMMOM_IMAGE_AMD64}"
+                            COMPOSE_IMAGE = "${COMPOSE_IMAGE_AMD64}"
+                        }
+                        stages {
+                            stage('amd64-redis'){
+                                environment {
+                                    USE_DB = '-redis'
+                                    USE_SECURITY ='-'
+                                }
+                                steps {
+                                    script {
+                                        startTest()
+                                    }
+                                }
+                            }
+                            stage('amd64-mongo'){
+                                environment {
+                                    USE_DB = '-mongo'
+                                    USE_SECURITY='-'
+                                }
+                                steps {
+                                    script {
+                                        startTest()
+                                    }
+                                }
+                            }
+                            // Comment out security job temporarily, will enable it after verification
+                            // stage('amd64-mongo-security'){
+                            //     environment {
+                            //         USE_DB = '-mongo'
+                            //         USE_SECURITY = '-security-'
+                            //     }
+                            //     steps {
+                            //         script {
+                            //             startTest()
+                            //         }
+                            //     }
+                            // }
+                        }
+                    }
+
+                    stage ('Run Test on arm64') {
+                        environment {
+                            ARCH = 'arm64'
+                            SLAVE = edgex.getNode(config, 'arm64')
+                            TAF_COMMOM_IMAGE = "${TAF_COMMOM_IMAGE_ARM64}"
+                            COMPOSE_IMAGE = "${COMPOSE_IMAGE_ARM64}"
+                        }
+                        stages {
+                            stage('arm64-redis'){
+                                environment {
+                                    USE_DB = '-redis'
+                                    USE_SECURITY ='-'
+                                }
+                                steps {
+                                    script {
+                                        startTest()
+                                    }
+                                }
+                            }                        
+                            stage('arm64-mongo'){
+                                environment {
+                                    USE_DB = '-mongo'
+                                    USE_SECURITY='-'
+                                }
+                                steps {
+                                    script {
+                                        startTest()
+                                    }
+                                }
+                            }
+                            // Comment out security job temporarily, will enable it after verification
+                            // stage('arm64-mongo-security'){
+                            //     environment {
+                            //         USE_DB = '-mongo'
+                            //         USE_SECURITY = '-security-'
+                            //     }
+                            //     steps {
+                            //         script {
+                            //             startTest()
+                            //         }
+                            //     }
+                            // }
+                        }
+                    }
+                }    
+            }
+
+            stage ('Publish Robotframework Report...') {
+                steps{
+                    script {
+                        def BRANCHES = "${BRANCHLIST}".split(',')
+                        for (z in BRANCHES) {
+                            def BRANCH = z
+
+                            catchError { unstash "x86_64-redis-${BRANCH}-report" }
+                            catchError { unstash "x86_64-mongo-${BRANCH}-report" }
+                            // catchError { unstash "x86_64-mongo-security-${BRANCH}-report" }
+                            catchError { unstash "arm64-redis-${BRANCH}-report" }
+                            catchError { unstash "arm64-mongo-${BRANCH}-report" }
+                            // catchError { unstash "arm64-mongo-security-${BRANCH}-report" }
+                        }
+                    
+                        dir ('TAF/testArtifacts/reports/merged-report/') {
+                            LOGFILES= sh (
+                                script: 'ls *-log.html | sed ":a;N;s/\\n/,/g;ta"',
+                                returnStdout: true
+                            )
+                        }
+                    }
+                    
+                    publishHTML(
+                        target: [
+                            allowMissing: false,
+                            alwaysLinkToLastBuild: true,
+                            keepAll: false,
+                            reportDir: 'TAF/testArtifacts/reports/merged-report',
+                            reportFiles: "${LOGFILES}",
+                            reportName: 'Functional Test Reports']
+                    )
+
+                    junit 'TAF/testArtifacts/reports/merged-report/**.xml'
+                }
+            }
+        }
+    }
+}
+
+def startTest() {
+    catchError {
+        timeout(time: 40, unit: 'MINUTES') {
+            def rootDir = pwd()
+            def runTestScripts = load "${rootDir}/runTestScripts.groovy"
+            runTestScripts.main()
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-
+This branch is for edgex-taf functional testing.
+Jenkinsfile - Trigger edgex-taf according variables, like x86_64, arm64, security, non-security, redis or mongo.
+runTestScripts.groovy - Run parallel stage for multiple branch.

--- a/runTestScripts.groovy
+++ b/runTestScripts.groovy
@@ -1,0 +1,98 @@
+
+def main() {
+    def BRANCHES = "${BRANCHLIST}".split(',')
+    def PROFILES = "${PROFILELIST}".split(',')
+    
+    def runbranchstage = [:]
+
+    for (x in BRANCHES) {
+        def BRANCH = x
+        
+        runbranchstage["Test ${ARCH}${USE_DB}${USE_SECURITY}${BRANCH}"]= {
+            node("${SLAVE}") {
+                stage ('Checkout edgex-taf repository') {
+                    checkout([$class: 'GitSCM',
+                        branches: [[name: "*/${BRANCH}"]],
+                        doGenerateSubmoduleConfigurations: false, 
+                        extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: '']], 
+                        submoduleCfg: [], 
+                        userRemoteConfigs: [[url: 'https://github.com/edgexfoundry/edgex-taf.git']]
+                        ])
+                }
+
+                stage ("Deploy EdgeX - ${ARCH}${USE_DB}${USE_SECURITY}${BRANCH}") {
+                    dir ('TAF/utils/scripts/docker') {
+                        sh "sh get-compose-file.sh ${USE_DB} ${ARCH} ${USE_SECURITY}"
+                        sh 'ls *.yml *.yaml'
+                    }
+
+                    sh "docker run --rm --network host -v ${env.WORKSPACE}:${env.WORKSPACE}:rw,z -w ${env.WORKSPACE} \
+                            -e COMPOSE_IMAGE=${COMPOSE_IMAGE} -v /var/run/docker.sock:/var/run/docker.sock ${TAF_COMMOM_IMAGE} \
+                            --exclude Skipped -u functionalTest/deploy-edgex.robot -p default"
+                }
+
+                echo "Profiles : ${PROFILES}"
+                stage ("Run Tests Script - ${ARCH}${USE_DB}${USE_SECURITY}${BRANCH}") {
+                    script {
+                        for (y in PROFILES) {
+                            def profile = y
+                            echo "Profile : ${profile}"
+                            echo "===== Deploy ${profile} ====="
+                            sh "docker run --rm --network host -v ${env.WORKSPACE}:${env.WORKSPACE}:rw,z -w ${env.WORKSPACE} \
+                                    -e COMPOSE_IMAGE=${COMPOSE_IMAGE} -e ARCH=${ARCH} \
+                                    -v /var/run/docker.sock:/var/run/docker.sock ${TAF_COMMOM_IMAGE} \
+                                    --exclude Skipped -u functionalTest/device-service/deploy_device_service.robot -p ${profile}"
+
+                            echo "===== Run ${profile} Test Case ====="
+                            sh "docker run --rm --network host -v ${env.WORKSPACE}:${env.WORKSPACE}:rw,z -w ${env.WORKSPACE} \
+                                    -e COMPOSE_IMAGE=${COMPOSE_IMAGE} -e ARCH=${ARCH} \
+                                    -v /var/run/docker.sock:/var/run/docker.sock ${TAF_COMMOM_IMAGE} \
+                                    --exclude Skipped -u functionalTest/device-service/common -p ${profile}"
+                            
+                            dir ('TAF/testArtifacts/reports/rename-report') {
+                                sh "cp ../edgex/log.html ${profile}-common-log.html"
+                                sh "cp ../edgex/report.xml ${profile}-common-report.xml"
+                            }
+
+                            echo "===== Shutdown ${profile} ====="
+                            sh "docker run --rm --network host -v ${env.WORKSPACE}:${env.WORKSPACE}:rw,z -w ${env.WORKSPACE} \
+                                    -e COMPOSE_IMAGE=${COMPOSE_IMAGE} -e ARCH=${ARCH} \
+                                    -v /var/run/docker.sock:/var/run/docker.sock ${TAF_COMMOM_IMAGE} \
+                                    --exclude Skipped -u functionalTest/device-service/shutdown_device_service.robot -p ${profile}"
+                        }
+                    }
+                }
+                stage ("Stash Report - ${ARCH}${USE_DB}${USE_SECURITY}${BRANCH}") {
+                    echo '===== Merge Reports ====='
+                    sh "docker run --rm --network host -v ${env.WORKSPACE}:${env.WORKSPACE}:rw,z -w ${env.WORKSPACE} \
+                                -e COMPOSE_IMAGE=${COMPOSE_IMAGE} -v /var/run/docker.sock:/var/run/docker.sock ${TAF_COMMOM_IMAGE} \
+                                rebot --inputdir TAF/testArtifacts/reports/rename-report \
+                                --outputdir TAF/testArtifacts/reports/${BRANCH}-report"
+
+                    dir ("TAF/testArtifacts/reports/${BRANCH}-report") {
+                        // Check if the merged-report folder exists
+                        def mergeExist = sh (
+                            script: 'ls ../ | grep merged-report',
+                            returnStatus: true
+                        )
+                        if (mergeExist != 0) {
+                            sh 'mkdir ../merged-report'
+                        }
+                        //Copy log file to merged-report folder
+                        sh "cp log.html ../merged-report/${ARCH}${USE_DB}${USE_SECURITY}${BRANCH}-log.html"
+                        sh "cp result.xml ../merged-report/${ARCH}${USE_DB}${USE_SECURITY}${BRANCH}-report.xml"
+                    }
+                    stash name: "${ARCH}${USE_DB}${USE_SECURITY}${BRANCH}-report", includes: "TAF/testArtifacts/reports/merged-report/*", allowEmpty: true
+                }
+                stage ("Shutdown EdgeX - ${ARCH}${USE_DB}${USE_SECURITY}${BRANCH}") {
+                    sh "docker run --rm --network host -v ${env.WORKSPACE}:${env.WORKSPACE}:rw,z -w ${env.WORKSPACE} \
+                            -e COMPOSE_IMAGE=${COMPOSE_IMAGE} -v /var/run/docker.sock:/var/run/docker.sock ${TAF_COMMOM_IMAGE} \
+                            --exclude Skipped -u functionalTest/shutdown.robot -p default"
+                }
+            }
+        }
+    }
+    parallel runbranchstage
+}
+
+return this


### PR DESCRIPTION
Run all non-security jobs
1. Use redis on x86-64
2. Use mongo on x86-64
3. Use redis on arm64
4. Use mongo on arm64.
5. Command out security-related stage which still needs to verify again.
Signed-off-by: Cherry Wang <cherry@iotechsys.com>
fix #2