### PR TITLE
[functional-test] Add redis security test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,6 @@ def call(config) {
         agent { label edgex.mainNode(config) }
         triggers { cron('H 6 * * *') }
         options { 
-            timeout(time: 3, unit: 'HOURS')
             timestamps()
         }
 
@@ -47,6 +46,17 @@ def call(config) {
                                 environment {
                                     USE_DB = '-redis'
                                     SECURITY_SERVICE_NEEDED = false
+                                }
+                                steps {
+                                    script {
+                                        startTest()
+                                    }
+                                }
+                            }
+                            stage('amd64-redis-security'){
+                                environment {
+                                    USE_DB = '-redis'
+                                    SECURITY_SERVICE_NEEDED = true
                                 }
                                 steps {
                                     script {
@@ -97,7 +107,18 @@ def call(config) {
                                         startTest()
                                     }
                                 }
-                            }                        
+                            }
+                            stage('arm64-redis-security'){
+                                environment {
+                                    USE_DB = '-redis'
+                                    SECURITY_SERVICE_NEEDED = true
+                                }
+                                steps {
+                                    script {
+                                        startTest()
+                                    }
+                                }
+                            }
                             stage('arm64-mongo'){
                                 environment {
                                     USE_DB = '-mongo'
@@ -133,9 +154,11 @@ def call(config) {
                             def BRANCH = z
 
                             catchError { unstash "x86_64-redis-${BRANCH}-report" }
+                            catchError { unstash "x86_64-redis-security-${BRANCH}-report" }
                             catchError { unstash "x86_64-mongo-${BRANCH}-report" }
                             catchError { unstash "x86_64-mongo-security-${BRANCH}-report" }
                             catchError { unstash "arm64-redis-${BRANCH}-report" }
+                            catchError { unstash "arm64-redis-security-${BRANCH}-report" }
                             catchError { unstash "arm64-mongo-${BRANCH}-report" }
                             catchError { unstash "arm64-mongo-security-${BRANCH}-report" }
                         }

--- a/runTestScripts.groovy
+++ b/runTestScripts.groovy
@@ -32,8 +32,8 @@ def main() {
 
                     sh "docker run --rm --network host -v ${env.WORKSPACE}:${env.WORKSPACE}:rw,z -w ${env.WORKSPACE} \
                             -e COMPOSE_IMAGE=${COMPOSE_IMAGE} -e SECURITY_SERVICE_NEEDED=${SECURITY_SERVICE_NEEDED} \
-                            -v /var/run/docker.sock:/var/run/docker.sock ${TAF_COMMOM_IMAGE} \
-                            --exclude Skipped -u functionalTest/deploy-edgex.robot -p default"
+                            -e USE_DB=${USE_DB} -v /var/run/docker.sock:/var/run/docker.sock ${TAF_COMMOM_IMAGE} \
+                            --exclude Skipped --include deploy-base-service -u deploy.robot -p default"
                 }
 
                 echo "Profiles : ${PROFILES}"
@@ -46,7 +46,7 @@ def main() {
                             sh "docker run --rm --network host -v ${env.WORKSPACE}:${env.WORKSPACE}:rw,z -w ${env.WORKSPACE} \
                                     -e COMPOSE_IMAGE=${COMPOSE_IMAGE} -e ARCH=${ARCH} \
                                     -v /var/run/docker.sock:/var/run/docker.sock ${TAF_COMMOM_IMAGE} \
-                                    --exclude Skipped -u functionalTest/device-service/deploy_device_service.robot -p ${profile}"
+                                    --exclude Skipped --include deploy-device-service -u deploy.robot -p ${profile}"
 
                             echo "===== Run ${profile} Test Case ====="
                             sh "docker run --rm --network host -v ${env.WORKSPACE}:${env.WORKSPACE}:rw,z -w ${env.WORKSPACE} \
@@ -63,7 +63,7 @@ def main() {
                             sh "docker run --rm --network host -v ${env.WORKSPACE}:${env.WORKSPACE}:rw,z -w ${env.WORKSPACE} \
                                     -e COMPOSE_IMAGE=${COMPOSE_IMAGE} -e ARCH=${ARCH} \
                                     -v /var/run/docker.sock:/var/run/docker.sock ${TAF_COMMOM_IMAGE} \
-                                    --exclude Skipped -u functionalTest/device-service/shutdown_device_service.robot -p ${profile}"
+                                    --exclude Skipped --include shutdown-device-service -u shutdown.robot -p ${profile}"
                         }
                     }
                 }
@@ -92,7 +92,7 @@ def main() {
                 stage ("Shutdown EdgeX - ${ARCH}${USE_DB}${USE_SECURITY}${BRANCH}") {
                     sh "docker run --rm --network host -v ${env.WORKSPACE}:${env.WORKSPACE}:rw,z -w ${env.WORKSPACE} \
                             -e COMPOSE_IMAGE=${COMPOSE_IMAGE} -v /var/run/docker.sock:/var/run/docker.sock ${TAF_COMMOM_IMAGE} \
-                            --exclude Skipped -u functionalTest/shutdown.robot -p default"
+                            --exclude Skipped --include shutdown-edgex -u shutdown.robot -p default"
                 }
             }
         }


### PR DESCRIPTION
- Add redis security test. Fix #14 
- Base on [edgex-taf PR #88](https://github.com/edgexfoundry/edgex-taf/pull/88) to update the deploy and shutdown command. 
- Remove duplicate timeout setting. Fix #8 

Signed-off-by: Cherry Wang <cherry@iotechsys.com>