### PR TITLE
[functional-test] Add --security-opt label:disable in docker run command

### DIFF
--- a/runTestScripts.groovy
+++ b/runTestScripts.groovy
@@ -32,7 +32,8 @@ def main() {
 
                     sh "docker run --rm --network host -v ${env.WORKSPACE}:${env.WORKSPACE}:rw,z -w ${env.WORKSPACE} \
                             -e COMPOSE_IMAGE=${COMPOSE_IMAGE} -e SECURITY_SERVICE_NEEDED=${SECURITY_SERVICE_NEEDED} \
-                            -e USE_DB=${USE_DB} -v /var/run/docker.sock:/var/run/docker.sock ${TAF_COMMOM_IMAGE} \
+                            -e USE_DB=${USE_DB} --security-opt label:disable \
+                            -v /var/run/docker.sock:/var/run/docker.sock ${TAF_COMMOM_IMAGE} \
                             --exclude Skipped --include deploy-base-service -u deploy.robot -p default"
                 }
 
@@ -44,13 +45,13 @@ def main() {
                             echo "Profile : ${profile}"
                             echo "===== Deploy ${profile} ====="
                             sh "docker run --rm --network host -v ${env.WORKSPACE}:${env.WORKSPACE}:rw,z -w ${env.WORKSPACE} \
-                                    -e COMPOSE_IMAGE=${COMPOSE_IMAGE} -e ARCH=${ARCH} \
+                                    -e COMPOSE_IMAGE=${COMPOSE_IMAGE} -e ARCH=${ARCH} --security-opt label:disable \
                                     -v /var/run/docker.sock:/var/run/docker.sock ${TAF_COMMOM_IMAGE} \
                                     --exclude Skipped --include deploy-device-service -u deploy.robot -p ${profile}"
 
                             echo "===== Run ${profile} Test Case ====="
                             sh "docker run --rm --network host -v ${env.WORKSPACE}:${env.WORKSPACE}:rw,z -w ${env.WORKSPACE} \
-                                    -e COMPOSE_IMAGE=${COMPOSE_IMAGE} -e ARCH=${ARCH} \
+                                    -e COMPOSE_IMAGE=${COMPOSE_IMAGE} -e ARCH=${ARCH} --security-opt label:disable \
                                     -v /var/run/docker.sock:/var/run/docker.sock ${TAF_COMMOM_IMAGE} \
                                     --exclude Skipped -u functionalTest/device-service/common -p ${profile}"
                             
@@ -61,7 +62,7 @@ def main() {
 
                             echo "===== Shutdown ${profile} ====="
                             sh "docker run --rm --network host -v ${env.WORKSPACE}:${env.WORKSPACE}:rw,z -w ${env.WORKSPACE} \
-                                    -e COMPOSE_IMAGE=${COMPOSE_IMAGE} -e ARCH=${ARCH} \
+                                    -e COMPOSE_IMAGE=${COMPOSE_IMAGE} -e ARCH=${ARCH} --security-opt label:disable \
                                     -v /var/run/docker.sock:/var/run/docker.sock ${TAF_COMMOM_IMAGE} \
                                     --exclude Skipped --include shutdown-device-service -u shutdown.robot -p ${profile}"
                         }
@@ -70,7 +71,7 @@ def main() {
                 stage ("Stash Report - ${ARCH}${USE_DB}${USE_SECURITY}${BRANCH}") {
                     echo '===== Merge Reports ====='
                     sh "docker run --rm --network host -v ${env.WORKSPACE}:${env.WORKSPACE}:rw,z -w ${env.WORKSPACE} \
-                                -e COMPOSE_IMAGE=${COMPOSE_IMAGE} -v /var/run/docker.sock:/var/run/docker.sock ${TAF_COMMOM_IMAGE} \
+                                -e COMPOSE_IMAGE=${COMPOSE_IMAGE} ${TAF_COMMOM_IMAGE} \
                                 rebot --inputdir TAF/testArtifacts/reports/rename-report \
                                 --outputdir TAF/testArtifacts/reports/${BRANCH}-report"
 
@@ -91,7 +92,8 @@ def main() {
                 }
                 stage ("Shutdown EdgeX - ${ARCH}${USE_DB}${USE_SECURITY}${BRANCH}") {
                     sh "docker run --rm --network host -v ${env.WORKSPACE}:${env.WORKSPACE}:rw,z -w ${env.WORKSPACE} \
-                            -e COMPOSE_IMAGE=${COMPOSE_IMAGE} -v /var/run/docker.sock:/var/run/docker.sock ${TAF_COMMOM_IMAGE} \
+                            -e COMPOSE_IMAGE=${COMPOSE_IMAGE} --security-opt label:disable \
+                            -v /var/run/docker.sock:/var/run/docker.sock ${TAF_COMMOM_IMAGE} \
                             --exclude Skipped --include shutdown-edgex -u shutdown.robot -p default"
                 }
             }


### PR DESCRIPTION
1. Add "--security-opt label:disable" in docker run command to fix permission issue.
2. Add choice parameter TEST_ARCH and WITH_SECURITY.
Fix #30

Signed-off-by: Cherry Wang <cherry@iotechsys.com>