### PR TITLE
Add Jenkins scripts for smoke test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,185 @@
+#!/usr/bin/env groovy
+def LOGFILES
+
+call([
+    project: 'smoke-test',
+])
+
+def call(config) {
+    edgex.bannerMessage "[smoke-testing] RAW Config: ${config}"
+
+    edgeXGeneric.validate(config)
+    edgex.setupNodes(config)
+
+    def _envVarMap = edgeXGeneric.toEnvironment(config)
+
+    pipeline {
+        agent { label edgex.mainNode(config) }
+        options {
+            timestamps()
+        }
+        parameters {
+            string(
+                name: 'SHA1',
+                defaultValue: 'master', 
+                description: 'GitHub PR Trigger provided parameter for specifying the commit to checkout. \
+                            For downloading docker-compose file from developer-script repo'
+            )
+            choice(name: 'TEST_ARCH', choices: ['All', 'x86_64', 'arm64'], description: 'Test environment')
+            choice(name: 'WITH_SECURITY', choices: ['All', 'No', 'Yes'], description: 'Test with security or non-security.')
+        }
+        environment {
+            // Define test branches and device services
+            BRANCHLIST = 'master'
+            TAF_COMMON_IMAGE_AMD64 = 'nexus3.edgexfoundry.org:10003/docker-edgex-taf-common:latest'
+            TAF_COMMON_IMAGE_ARM64 = 'nexus3.edgexfoundry.org:10003/docker-edgex-taf-common-arm64:latest'
+            COMPOSE_IMAGE_AMD64 = 'nexus3.edgexfoundry.org:10003/edgex-devops/edgex-compose:latest'
+            COMPOSE_IMAGE_ARM64 = 'nexus3.edgexfoundry.org:10003/edgex-devops/edgex-compose-arm64:latest'
+        }
+        stages {
+            stage ('Run Test') {
+                parallel {
+                    stage ('Run Smoke Test on amd64') {
+                        when { 
+                            expression { params.TEST_ARCH == 'All' || params.TEST_ARCH == 'x86_64' }
+                        }
+                        environment {
+                            ARCH = 'x86_64'
+                            SLAVE = edgex.getNode(config, 'amd64')
+                            TAF_COMMON_IMAGE = "${TAF_COMMON_IMAGE_AMD64}"
+                            COMPOSE_IMAGE = "${COMPOSE_IMAGE_AMD64}"
+                        }
+                        stages {
+                            stage('amd64-redis'){
+                                when { 
+                                    expression { params.WITH_SECURITY == 'All' || params.WITH_SECURITY == 'No' }
+                                }
+                                environment {
+                                    USE_DB = '-redis'
+                                    SECURITY_SERVICE_NEEDED = false
+                                }
+                                steps {
+                                    script {
+                                        smokeTest()
+                                    }
+                                }
+                            }
+                            stage('amd64-redis-security'){
+                                when { 
+                                    expression { params.WITH_SECURITY == 'All' || params.WITH_SECURITY == 'Yes' }
+                                }
+                                environment {
+                                    USE_DB = '-redis'
+                                    SECURITY_SERVICE_NEEDED = true
+                                }
+                                steps {
+                                    script {
+                                        smokeTest()
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    stage ('Run Smoke Test on arm64') {
+                        when { 
+                            expression { params.TEST_ARCH == 'All' || params.TEST_ARCH == 'arm64' }
+                        }
+                        environment {
+                            ARCH = 'arm64'
+                            SLAVE = edgex.getNode(config, 'arm64')
+                            TAF_COMMON_IMAGE = "${TAF_COMMON_IMAGE_ARM64}"
+                            COMPOSE_IMAGE = "${COMPOSE_IMAGE_ARM64}"
+                        }
+                        stages {
+                            stage('arm64-redis'){
+                                when { 
+                                    expression { params.WITH_SECURITY == 'All' || params.WITH_SECURITY == 'No' }
+                                }
+                                environment {
+                                    USE_DB = '-redis'
+                                    SECURITY_SERVICE_NEEDED = false
+                                }
+                                steps {
+                                    script {
+                                        smokeTest()
+                                    }
+                                }
+                            }
+                            stage('arm64-redis-security'){
+                                when { 
+                                    expression { params.WITH_SECURITY == 'All' || params.WITH_SECURITY == 'Yes' }
+                                }
+                                environment {
+                                    USE_DB = '-redis'
+                                    SECURITY_SERVICE_NEEDED = true
+                                }
+                                steps {
+                                    script {
+                                        smokeTest()
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            stage ('Publish Robotframework Report...') {
+                steps{
+                    script {
+                        def BRANCHES = "${BRANCHLIST}".split(',')
+                        for (z in BRANCHES) {
+                            def BRANCH = z
+
+                            // Smoke Test Report
+                            if (("${params.TEST_ARCH}" == 'All' || "${params.TEST_ARCH}" == 'x86_64')) {
+                                if (("${params.WITH_SECURITY}" == 'All' || "${params.WITH_SECURITY}" == 'No')) {
+                                    catchError { unstash "smoke-x86_64-redis-${BRANCH}-report" }
+                                } 
+                                if (("${params.WITH_SECURITY}" == 'All' || "${params.WITH_SECURITY}" == 'Yes')) {
+                                    catchError { unstash "smoke-x86_64-redis-security-${BRANCH}-report" }
+                                }
+                            }
+                            if (("${params.TEST_ARCH}" == 'All' || "${params.TEST_ARCH}" == 'arm64')) {
+                                if (("${params.WITH_SECURITY}" == 'All' || "${params.WITH_SECURITY}" == 'No')) {
+                                    catchError { unstash "smoke-arm64-redis-${BRANCH}-report" }
+                                } 
+                                if (("${params.WITH_SECURITY}" == 'All' || "${params.WITH_SECURITY}" == 'Yes')) {
+                                    catchError { unstash "smoke-arm64-redis-security-${BRANCH}-report" }
+                                }
+                            }
+                        }
+
+                        dir ('TAF/testArtifacts/reports/merged-report/') {
+                            SMOKE_LOGFILES= sh (
+                                script: 'ls smoke-*-log.html | sed ":a;N;s/\\n/,/g;ta"',
+                                returnStdout: true
+                            )
+                            publishHTML(
+                                target: [
+                                    allowMissing: false,
+                                    alwaysLinkToLastBuild: false,
+                                    keepAll: true,
+                                    reportDir: '.',
+                                    reportFiles: "${SMOKE_LOGFILES}",
+                                    reportName: 'Smoke Test Reports']
+                            )
+                        }
+                    }
+                    
+                    junit 'TAF/testArtifacts/reports/merged-report/**.xml'
+                }                                         
+            }
+        }
+    }
+} 
+
+
+def smokeTest() {
+    catchError {
+        timeout(time: 30, unit: 'MINUTES') {
+            def rootDir = pwd()
+            def runSmokeTestScripts = load "${rootDir}/runSmokeTestScripts.groovy"
+            runSmokeTestScripts.main()
+        }
+    }      
+}

--- a/runSmokeTestScripts.groovy
+++ b/runSmokeTestScripts.groovy
@@ -1,0 +1,108 @@
+def main() {
+    def BRANCHES = "${BRANCHLIST}".split(',')
+    def USE_SECURITY = '-'
+    def runbranchstage = [:]
+
+    for (x in BRANCHES) {
+        if ("${SECURITY_SERVICE_NEEDED}" == 'true') {
+            USE_SECURITY = '-security-'
+        }
+
+        def BRANCH = x
+
+        runbranchstage["SmokeTest ${ARCH}${USE_DB}${USE_SECURITY}${BRANCH}"]= {
+            node("${SLAVE}") {
+                stage ('Checkout edgex-taf repository') {
+                    checkout([$class: 'GitSCM',
+                        branches: [[name: "*/${BRANCH}"]],
+                        doGenerateSubmoduleConfigurations: false, 
+                        extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: '']], 
+                        submoduleCfg: [], 
+                        userRemoteConfigs: [[url: 'https://github.com/edgexfoundry/edgex-taf.git']]
+                        ])
+                }
+
+                stage ("Deploy EdgeX - ${ARCH}${USE_DB}${USE_SECURITY}${BRANCH}") {
+                    dir ('TAF/utils/scripts/docker') {
+                        sh "sh get-compose-file.sh ${USE_DB} ${ARCH} ${USE_SECURITY} nightly-build ${params.SHA1}"
+                        sh 'ls *.yml *.yaml'
+                    }
+
+                    sh "docker run --rm --network host -v ${env.WORKSPACE}:${env.WORKSPACE}:z -w ${env.WORKSPACE} \
+                            -e COMPOSE_IMAGE=${COMPOSE_IMAGE} -e SECURITY_SERVICE_NEEDED=${SECURITY_SERVICE_NEEDED} \
+                            -e USE_DB=${USE_DB} --security-opt label:disable \
+                            -v /var/run/docker.sock:/var/run/docker.sock ${TAF_COMMON_IMAGE} \
+                            --exclude Skipped --include deploy-base-service -u deploy.robot -p default"
+                }
+
+                stage ("Run Functional Tests Script - ${ARCH}${USE_DB}${USE_SECURITY}${BRANCH}") {
+                    sh "docker run --rm --network host -v ${env.WORKSPACE}:${env.WORKSPACE}:z -w ${env.WORKSPACE} \
+                                    -e COMPOSE_IMAGE=${COMPOSE_IMAGE} -e ARCH=${ARCH} --security-opt label:disable \
+                                    -v /var/run/docker.sock:/var/run/docker.sock ${TAF_COMMON_IMAGE} \
+                                    --exclude Skipped --include deploy-device-service -u deploy.robot -p device-virtual"
+
+                    sh "docker run --rm --network host -v ${env.WORKSPACE}:${env.WORKSPACE}:z -w ${env.WORKSPACE} \
+                            --security-opt label:disable -e COMPOSE_IMAGE=${COMPOSE_IMAGE} -e ARCH=${ARCH} \
+                            -e SECURITY_SERVICE_NEEDED=${SECURITY_SERVICE_NEEDED} \
+                            -v /var/run/docker.sock:/var/run/docker.sock ${TAF_COMMON_IMAGE} \
+                            --exclude Skipped --include SmokeTest -u functionalTest -p device-virtual"
+                    
+                    dir ('TAF/testArtifacts/reports/rename-report') {
+                        sh "cp ../edgex/log.html functional-log.html"
+                        sh "cp ../edgex/report.xml functional-report.xml"
+                    }
+                    sh "docker run --rm --network host -v ${env.WORKSPACE}:${env.WORKSPACE}:z -w ${env.WORKSPACE} \
+                                    -e COMPOSE_IMAGE=${COMPOSE_IMAGE} -e ARCH=${ARCH} --security-opt label:disable \
+                                    -v /var/run/docker.sock:/var/run/docker.sock ${TAF_COMMON_IMAGE} \
+                                    --exclude Skipped --include shutdown-device-service -u shutdown.robot -p device-virtual"
+                }
+
+                stage ("Run Integration Tests Script - ${ARCH}${USE_DB}${USE_SECURITY}${BRANCH}") {
+                    sh "docker run --rm --network host -v ${env.WORKSPACE}:${env.WORKSPACE}:z -w ${env.WORKSPACE} \
+                            --security-opt label:disable -e COMPOSE_IMAGE=${COMPOSE_IMAGE} -e ARCH=${ARCH} \
+                            -e SECURITY_SERVICE_NEEDED=${SECURITY_SERVICE_NEEDED} \
+                            -v /var/run/docker.sock:/var/run/docker.sock ${TAF_COMMON_IMAGE} \
+                            --exclude Skipped --include SmokeTest -u integrationTest -p device-virtual"
+                
+                    dir ('TAF/testArtifacts/reports/rename-report') {
+                        sh "cp ../edgex/log.html integration-log.html"
+                        sh "cp ../edgex/report.xml integration-report.xml"
+                    }
+                }
+
+                stage ("Stash Report - ${ARCH}${USE_DB}${USE_SECURITY}${BRANCH}") {
+                    echo '===== Merge Reports ====='
+                    sh "docker run --rm --network host -v ${env.WORKSPACE}:${env.WORKSPACE}:z -w ${env.WORKSPACE} \
+                                -e COMPOSE_IMAGE=${COMPOSE_IMAGE} ${TAF_COMMON_IMAGE} \
+                                rebot --inputdir TAF/testArtifacts/reports/rename-report \
+                                --outputdir TAF/testArtifacts/reports/smoke-${BRANCH}-report"
+
+                    dir ("TAF/testArtifacts/reports/smoke-${BRANCH}-report") {
+                        // Check if the merged-report folder exists
+                        def mergeExist = sh (
+                            script: 'ls ../ | grep merged-report',
+                            returnStatus: true
+                        )
+                        if (mergeExist != 0) {
+                            sh 'mkdir ../merged-report'
+                        }
+                        //Copy log file to merged-report folder
+                        sh "cp log.html ../merged-report/smoke-${ARCH}${USE_DB}${USE_SECURITY}${BRANCH}-log.html"
+                        sh "cp result.xml ../merged-report/smoke-${ARCH}${USE_DB}${USE_SECURITY}${BRANCH}-report.xml"
+                    }
+                    stash name: "smoke-${ARCH}${USE_DB}${USE_SECURITY}${BRANCH}-report", includes: "TAF/testArtifacts/reports/merged-report/*", allowEmpty: true
+                }
+
+                stage ("Shutdown EdgeX - ${ARCH}${USE_DB}${USE_SECURITY}${BRANCH}") {
+                    sh "docker run --rm --network host -v ${env.WORKSPACE}:${env.WORKSPACE}:z -w ${env.WORKSPACE} \
+                            -e COMPOSE_IMAGE=${COMPOSE_IMAGE} --security-opt label:disable \
+                            -v /var/run/docker.sock:/var/run/docker.sock ${TAF_COMMON_IMAGE} \
+                            --exclude Skipped --include shutdown-edgex -u shutdown.robot -p default"
+                }                             
+            }
+        }
+    }
+    parallel runbranchstage
+}
+
+return this


### PR DESCRIPTION
The test result on Jenkins Sandbox, please see attached image or url for reference.

Fix #42 
![image](https://user-images.githubusercontent.com/41656797/95291802-d9fea300-08a2-11eb-98ba-f00edb10d6ae.png)

https://jenkins.edgexfoundry.org/sandbox/blue/organizations/jenkins/TAF%2Ftaf-smoke-test/detail/taf-smoke-test/8/pipeline

Related to edgex-taf [PR #193](https://github.com/edgexfoundry/edgex-taf/pull/193) and [PR #194](https://github.com/edgexfoundry/edgex-taf/pull/194).

Signed-off-by: Cherry Wang <cherry@iotechsys.com>