### PR TITLE
Set default test_strategy to IntegrationTest

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,7 @@ def call(config) {
             timestamps()
         }
         parameters {
-            choice(name: 'TEST_STRATEGY', choices: ['All', 'IntegrationTest', 'BackwardTest'])
+            choice(name: 'TEST_STRATEGY', choices: ['IntegrationTest', 'BackwardTest', 'All'])
             choice(name: 'TEST_ARCH', choices: ['All', 'x86_64', 'arm64'])
             choice(name: 'WITH_SECURITY', choices: ['All', 'No', 'Yes'])
         }


### PR DESCRIPTION
Set default test_strategy to IntegrationTest, the Jenkins job will only run IntegrationTest when triggering by cron.

Fix #44 
Signed-off-by: Cherry Wang <cherry@iotechsys.com>
