### PR TITLE
[functional-test] Extend timeout time

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -170,7 +170,7 @@ def call(config) {
 
 def startTest() {
     catchError {
-        timeout(time: 1, unit: 'HOURS') {
+        timeout(time: 80, unit: 'MINUTES') {
             def rootDir = pwd()
             def runTestScripts = load "${rootDir}/runTestScripts.groovy"
             runTestScripts.main()


### PR DESCRIPTION
Extend timeout time to 80 minutes to avoid arm64 with security Jenkins Job failed.
Signed-off-by: Cherry Wang <cherry@iotechsys.com>