### PR TITLE
[functional-test] fix: Update compose image to use Compose v2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,8 +32,7 @@ def call(config) {
             PROFILELIST = 'device-virtual,device-modbus'
             TAF_COMMON_IMAGE_AMD64 = 'nexus3.edgexfoundry.org:10003/edgex-taf-common:latest'
             TAF_COMMON_IMAGE_ARM64 = 'nexus3.edgexfoundry.org:10003/edgex-taf-common-arm64:latest'
-            COMPOSE_IMAGE_AMD64 = 'nexus3.edgexfoundry.org:10003/edgex-devops/edgex-compose:latest'
-            COMPOSE_IMAGE_ARM64 = 'nexus3.edgexfoundry.org:10003/edgex-devops/edgex-compose-arm64:latest'
+            COMPOSE_IMAGE = 'docker:20.10.18'
             TAF_BRANCH = "${params.TAF_BRANCH}"
             COMPOSE_BRANCH = "${params.COMPOSE_BRANCH}"
         }
@@ -49,7 +48,6 @@ def call(config) {
                             ARCH = 'x86_64'
                             NODE = edgex.getNode(config, 'amd64')
                             TAF_COMMON_IMAGE = "${TAF_COMMON_IMAGE_AMD64}"
-                            COMPOSE_IMAGE = "${COMPOSE_IMAGE_AMD64}"
                         }
                         stages {
                             stage('amd64'){
@@ -89,7 +87,6 @@ def call(config) {
                             ARCH = 'arm64'
                             NODE = edgex.getNode(config, 'arm64')
                             TAF_COMMON_IMAGE = "${TAF_COMMON_IMAGE_ARM64}"
-                            COMPOSE_IMAGE = "${COMPOSE_IMAGE_ARM64}"
                         }
                         stages {
                             stage('arm64'){


### PR DESCRIPTION
Update compose image to `docker:20.10.18` which contain compose v2

Signed-off-by: Cherry Wang <cherry@iotechsys.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->