### PR TITLE
fix: Extend timeout time for arm64 security integration-test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -171,7 +171,7 @@ def call(config) {
 
 def integrationTest() {
     catchError {
-        timeout(time: 50, unit: 'MINUTES') {
+        timeout(time: 70, unit: 'MINUTES') {
             def rootDir = pwd()
             def runIntegrationTestScripts = load "${rootDir}/runIntegrationTestScripts.groovy"
             runIntegrationTestScripts.main()


### PR DESCRIPTION
Extend timeout time from 50 minutes to 70 minutes for arm64 security integration-test
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->